### PR TITLE
feat: integrate Beer CSS with theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,140 +3,32 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Prompt Bubbles — Curated ChatGPT Prompts</title>
+<title>Prompt Bubbles — Curated ChatGPT Prompts</title>
   <meta name="color-scheme" content="dark light" />
-  <style>
-    :root{
-      --bg-a:#0b1016; --bg-b:#0f1620; --bg-c:#172230;
-      --text-0:#eaf1fb; --text-1:#aab7cc;
-      --brand:#6ee7ff; --brand-2:#b892ff;
-      --chip:#131c28; --chip-text:#d9e6fb;
-      --ring:#7ad1ff; --ok:#70ffa6;
-      --shadow:0 10px 30px rgba(0,0,0,.35);
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beercss.min.css" />
+  <script>
+    const THEME_STORAGE_KEY = "preferred-theme";
+    const LIGHT_THEME = "light";
+    const DARK_THEME = "dark";
+    /** initializeTheme applies a persisted theme preference. */
+    function initializeTheme() {
+      const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+      const theme = savedTheme === DARK_THEME ? DARK_THEME : LIGHT_THEME;
+      document.documentElement.setAttribute("data-theme", theme);
     }
-    @media (prefers-color-scheme: light){
-      :root{
-        --bg-a:#f8fbff; --bg-b:#eef4ff; --bg-c:#e8effb;
-        --text-0:#0f1c2b; --text-1:#3a4f68;
-        --chip:#e9f1ff; --chip-text:#0f1c2b;
-        --ring:#2a83cf; --shadow:0 8px 24px rgba(0,40,80,.12);
-      }
-    }
-
-    *{box-sizing:border-box}
-    html,body{height:100%}
-    body{
-      margin:0;
-      font:16px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Helvetica Neue,Arial,Noto Sans,Apple Color Emoji,Segoe UI Emoji;
-      color:var(--text-0);
-      /* Smooth, non-tiled background */
-      background: linear-gradient(130deg, var(--bg-a) 0%, var(--bg-b) 40%, var(--bg-c) 100%) fixed;
-      position:relative;
-    }
-    /* Subtle vignette for depth, not blotches */
-    body::before{
-      content:"";
-      position:fixed; inset:0; pointer-events:none;
-      background: radial-gradient(1200px 800px at 50% -200px, rgba(255,255,255,.08), transparent 60%),
-      radial-gradient(1200px 800px at 50% 120%, rgba(255,255,255,.04), transparent 60%);
-      opacity:.5;
-    }
-
-    .shell{max-width:1200px; margin:0 auto; padding:18px clamp(16px,4vw,32px) 40px;}
-
-    /* --- TOP SEARCH BAR --- */
-    .topsearch{
-      position:sticky; top:0; z-index:20;
-      padding:14px 0;
-      backdrop-filter:saturate(1.1) blur(8px);
-      -webkit-backdrop-filter:saturate(1.1) blur(8px);
-      background: linear-gradient(180deg, rgba(0,0,0,.25), rgba(0,0,0,0));
-      border-bottom:1px solid rgba(255,255,255,.06);
-    }
-    .searchrow{ display:grid; grid-template-columns: 1fr auto; gap:12px; align-items:center; }
-    .searchbox{ position:relative; }
-    .searchbox input{
-      width:100%;
-      padding:18px 56px 18px 56px;
-      border-radius:22px;
-      border:1px solid rgba(255,255,255,.12);
-      background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-      color:var(--text-0);
-      font-size:18px;
-      outline:none;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,.06), var(--shadow);
-    }
-    .searchbox input:focus{ outline:2px solid var(--ring); outline-offset:2px }
-    .searchbox svg{ position:absolute; left:18px; top:50%; transform:translateY(-50%); width:22px; height:22px; opacity:.9; }
-    .search-clear{ position:absolute; right:14px; top:50%; transform:translateY(-50%); border:0; background:transparent; color:var(--text-1); cursor:pointer; padding:8px; border-radius:10px; }
-    .search-clear:hover{ color:var(--text-0) }
-
-    /* --- TITLE + CHIPS --- */
-    header{ padding:18px 0 6px; }
-    .titlebar{ display:flex; align-items:center; gap:14px; flex-wrap:wrap; }
-    .logo{ width:42px; height:42px; border-radius:12px;
-      background: linear-gradient(135deg, var(--brand), var(--brand-2));
-      box-shadow:var(--shadow);
-    }
-    h1{ margin:0; font-size:clamp(22px,3.2vw,34px); font-weight:800; letter-spacing:.2px; }
-    .subtitle{ margin:6px 0 0 56px; color:var(--text-1); font-size:14px; }
-
-    .chips{ margin-top:14px; display:flex; flex-wrap:wrap; gap:8px; }
-    .chip{
-      border:1px solid rgba(255,255,255,.14);
-      background:var(--chip); color:var(--chip-text);
-      padding:8px 12px; border-radius:999px; font-size:13px; cursor:pointer; user-select:none; transition:transform .06s ease;
-    }
-    .chip[data-active="true"]{
-      background: linear-gradient(135deg, color-mix(in oklab, var(--brand) 65%, transparent), color-mix(in oklab, var(--brand-2) 65%, transparent));
-      color:#061018; border-color:transparent;
-    }
-    .chip:active{ transform:scale(.98) }
-
-    main{ margin-top:16px }
-    .grid{ display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:16px; }
-
-    .card{
-      position:relative; display:flex; flex-direction:column; gap:12px;
-      border-radius:22px; padding:16px 16px 52px 16px;
-      background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-      border:1px solid rgba(255,255,255,.12); box-shadow:var(--shadow); overflow:hidden; isolation:isolate;
-    }
-    .card:hover{ transform:translateY(-1px) }
-    .card:focus-within{ outline:2px solid var(--ring) }
-
-    .card-header{ display:flex; align-items:center; gap:10px; }
-    .tag-dot{ width:10px; height:10px; border-radius:50%; background: radial-gradient(circle at 30% 30%, var(--brand), var(--brand-2)); box-shadow:0 0 0 3px color-mix(in lab, var(--brand) 20%, transparent); }
-    .card-title{ margin:0; font-size:15px; font-weight:700; letter-spacing:.2px; }
-    .card-tags{ display:flex; flex-wrap:wrap; gap:6px; margin-top:-2px; }
-    .tag{ font-size:11px; padding:4px 8px; border-radius:999px; background:color-mix(in lab, var(--brand) 14%, transparent); color:color-mix(in lab, var(--text-0) 85%, var(--brand)); border:1px dashed color-mix(in lab, var(--brand-2) 40%, transparent); }
-    .card-text{ white-space:pre-wrap; font-size:14px; color:var(--text-0); }
-
-    .card-actions{ position:absolute; right:10px; bottom:10px; display:flex; gap:8px; }
-    .btn{ display:inline-flex; align-items:center; gap:8px; border:1px solid rgba(255,255,255,.16); background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02)); padding:8px 12px; border-radius:12px; cursor:pointer; user-select:none; color:var(--text-0); }
-    .btn:hover{ border-color: color-mix(in lab, var(--brand) 40%, transparent) }
-    .btn:active{ transform: translateY(1px) }
-    .btn svg{ width:18px; height:18px }
-
-    .copied{ position:absolute; left:12px; bottom:10px; font-size:12px; padding:6px 10px; border-radius:10px; background: color-mix(in lab, var(--ok) 20%, var(--bg-c)); color: color-mix(in lab, var(--text-0) 60%, var(--ok)); border: 1px solid color-mix(in lab, var(--ok) 35%, transparent); opacity:0; transform: translateY(6px); transition:all .18s ease; pointer-events:none; }
-    .copied[data-show="true"]{ opacity:1; transform:translateY(0) }
-
-    .footer{ margin-top:26px; color:var(--text-1); font-size:12px; text-align:center; }
-
-    @media (prefers-reduced-motion: reduce){ *{transition:none !important; animation:none !important} }
-  </style>
+    initializeTheme();
+  </script>
+  <script defer src="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beercss.min.js"></script>
 </head>
 <body>
-<div class="shell">
-  <!-- Top search row -->
-  <div class="topsearch">
-    <div class="searchrow" role="region" aria-label="Search">
-      <div class="searchbox">
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23C15.99 6.01 13.48 3.5 10.49 3.5S5 6.01 5 9s2.51 5.5 5.5 5.5a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L20 20.49 21.49 19 15.5 14Zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14Z"/></svg>
-        <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
-        <button class="search-clear" id="clearSearch" title="Clear search" aria-label="Clear search">✕</button>
-      </div>
+<div class="container">
+  <div class="search" role="region" aria-label="Search">
+    <div class="field prefix suffix">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23C15.99 6.01 13.48 3.5 10.49 3.5S5 6.01 5 9s2.51 5.5 5.5 5.5a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L20 20.49 21.49 19 15.5 14Zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14Z"/></svg>
+      <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
+      <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search">✕</button>
     </div>
+    <button class="icon" id="themeToggle" title="Toggle theme" aria-label="Toggle theme" data-ui="dark">🌓</button>
   </div>
 
   <header>
@@ -155,7 +47,6 @@
 </div>
 
 <script>
-  // ====== DATA (keep yours or merge) ======
   const PROMPTS = [
     { id: "p01", title: "Ultra‑tight Bug Report Summarizer", text: `You are a senior SRE. Summarize the following bug/incident:
 - Extract root cause in one sentence.
@@ -564,11 +455,7 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   ];
 
 
-
-  // ====== STATE ======
   const state = { search:"", tag:"all" };
-
-  // ====== HELPERS ======
   const $ = (s, r=document)=>r.querySelector(s);
   const $$ = (s, r=document)=>Array.from(r.querySelectorAll(s));
   const debounce=(fn,ms=120)=>{let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),ms)}};
@@ -579,8 +466,6 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
     const hay=(item.title+" "+item.text+" "+item.tags.join(" ")).toLowerCase();
     return tagOk && q.split(/\s+/).every(tok=>hay.includes(tok));
   };
-
-  // ====== RENDERING ======
   function uniqueTags(){
     const t=new Set(); PROMPTS.forEach(p=>p.tags.forEach(tag=>t.add(tag)));
     return ["all",...Array.from(t).sort((a,b)=>a.localeCompare(b))];
@@ -641,18 +526,25 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   function copyIcon(){ return `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`; }
   function escapeHTML(s){ return s.replace(/[&<>"']/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch])); }
 
-  // ====== SEARCH + PERSIST ======
   const onSearch = debounce((v)=>{ state.search=v; persist(); renderGrid(); },80);
   function persist(){ try{ localStorage.setItem("prompt-bubbles-state", JSON.stringify(state)); }catch{} }
   function restore(){ try{ const raw=localStorage.getItem("prompt-bubbles-state"); if(raw){ const p=JSON.parse(raw); if(typeof p.search==="string") state.search=p.search; if(typeof p.tag==="string") state.tag=p.tag; } }catch{} }
 
-  // ====== INIT ======
+  /** toggleTheme switches between light and dark themes. */
+  function toggleTheme() {
+    const nextTheme = document.documentElement.getAttribute("data-theme") === DARK_THEME ? LIGHT_THEME : DARK_THEME;
+    document.documentElement.setAttribute("data-theme", nextTheme);
+    localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+  }
+
+  /** init prepares interactive elements. */
   function init(){
     restore(); renderChips(); renderGrid();
-    const input=$("#searchInput"), clear=$("#clearSearch");
+    const input=$("#searchInput"), clear=$("#clearSearch"), themeButton=$("#themeToggle");
     input.value=state.search;
     input.addEventListener("input",(e)=>onSearch(e.target.value));
     clear.addEventListener("click",()=>{ input.value=""; input.focus(); onSearch(""); });
+    themeButton.addEventListener("click", toggleTheme);
     window.addEventListener("keydown",(e)=>{ if(e.key==="/" && document.activeElement!==input){ e.preventDefault(); input.focus(); input.select(); }});
   }
   document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- replace custom styles with Beer CSS CDN assets
- wrap search bar in Beer CSS classes and add theme toggle
- persist preferred theme in localStorage and initialize on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a522d5524483279db118011e707543