### PR TITLE
Adopt BeerCSS layout for prompt gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,14 +21,16 @@
   <script defer src="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beercss.min.js"></script>
 </head>
 <body class="light">
-<div class="container">
-  <div class="search" role="region" aria-label="Search">
-    <div class="field prefix suffix">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23C15.99 6.01 13.48 3.5 10.49 3.5S5 6.01 5 9s2.51 5.5 5.5 5.5a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L20 20.49 21.49 19 15.5 14Zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14Z"/></svg>
-      <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
-      <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search">✕</button>
+<main class="responsive padding">
+  <div class="row max center">
+    <div class="search" role="region" aria-label="Search">
+      <div class="field prefix suffix">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23C15.99 6.01 13.48 3.5 10.49 3.5S5 6.01 5 9s2.51 5.5 5.5 5.5a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L20 20.49 21.49 19 15.5 14Zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14Z"/></svg>
+        <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
+        <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search">✕</button>
+      </div>
+      <button class="icon" id="themeToggle" title="Toggle theme" aria-label="Toggle theme" data-ui="dark">🌓</button>
     </div>
-    <button class="icon" id="themeToggle" title="Toggle theme" aria-label="Toggle theme" data-ui="dark">🌓</button>
   </div>
 
   <header>
@@ -40,11 +42,9 @@
     <div id="chipBar" aria-label="Tag filters"></div>
   </header>
 
-  <main>
-    <section class="grid" id="grid" role="list" aria-label="Prompt cards"></section>
-    <p class="footer">Tip: Press <strong>/</strong> to jump to search • Press <strong>Enter</strong> on a focused card to copy</p>
-  </main>
-</div>
+  <section class="grid large" id="grid" role="list" aria-label="Prompt cards"></section>
+  <p class="footer">Tip: Press <strong>/</strong> to jump to search • Press <strong>Enter</strong> on a focused card to copy</p>
+</main>
 
 <script type="module" src="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beer.min.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/material-dynamic-colors@latest/dist/cdn/material-dynamic-colors.min.js"></script>


### PR DESCRIPTION
## Summary
- replace legacy container div with `main` using BeerCSS responsive padding
- wrap search bar in BeerCSS `row` for centered max-width layout
- render prompts within BeerCSS `grid large` section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5564c2e148327821580088d7a1995