### PR TITLE
Use Beer.css chips and snackbar for prompt cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,14 +464,13 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   const CLASS_BUTTON = "button";
   const CLASS_CHIPS = "chips";
   const CLASS_CHIP = "chip";
-  const CLASS_COPIED = "copied";
-  /** CLASS_TAG_DOT is the CSS class for the tag indicator. */
-  const CLASS_TAG_DOT = "tag-dot";
+  /** SNACKBAR_CLASS_NAME is the class and component name for Beer.css snackbars. */
+  const SNACKBAR_CLASS_NAME = "snackbar";
   const COPY_PROMPT_LABEL_PREFIX = "Copy prompt:";
   const COPY_BUTTON_LABEL = "Copy";
-  const COPIED_TOAST_MESSAGE = "Copied \u2713";
+  /** COPY_SNACKBAR_MESSAGE is the text shown after a prompt is copied. */
+  const COPY_SNACKBAR_MESSAGE = "Copied \u2713";
   const DATA_ACTIVE_ATTRIBUTE = "data-active";
-  const DATA_SHOW_ATTRIBUTE = "data-show";
   const NO_MATCH_MESSAGE = "No prompts match your search/filter.";
   const EVENT_INPUT = "input";
   const EVENT_CLICK = "click";
@@ -579,42 +578,38 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   }
 
     /** createCard builds a card element for a prompt. */
-    function createCard(item){
+    function createCard(promptItem){
       const cardElement=document.createElement("article"); cardElement.className=CLASS_CARD; cardElement.setAttribute("role","listitem"); cardElement.tabIndex=0;
 
       const contentElement=document.createElement("div"); contentElement.className=CLASS_CONTENT;
       const titleContainerElement=document.createElement("div");
-      const tagDotElement=document.createElement("span");
-      tagDotElement.className=CLASS_TAG_DOT;
-      tagDotElement.setAttribute("aria-hidden","true");
       const titleHeadingElement=document.createElement("h3");
-      titleHeadingElement.innerHTML=escapeHTML(item.title);
-      titleContainerElement.appendChild(tagDotElement);
+      titleHeadingElement.innerHTML=escapeHTML(promptItem.title);
       titleContainerElement.appendChild(titleHeadingElement);
       contentElement.appendChild(titleContainerElement);
 
-      const tagContainerElement=document.createElement("div"); tagContainerElement.className=CLASS_CHIPS;
-      item.tags.forEach(tagName=>{ const tagChipElement=document.createElement("div"); tagChipElement.className=CLASS_CHIP; tagChipElement.textContent=tagName; tagContainerElement.appendChild(tagChipElement); });
-      contentElement.appendChild(tagContainerElement);
+      const chipContainerElement=document.createElement("div"); chipContainerElement.className=CLASS_CHIPS;
+      promptItem.tags.forEach(tagName=>{ const chipElement=document.createElement("div"); chipElement.className=CLASS_CHIP; chipElement.textContent=tagName; chipContainerElement.appendChild(chipElement); });
+      contentElement.appendChild(chipContainerElement);
 
-      const textElement=document.createElement("pre"); textElement.textContent=item.text; contentElement.appendChild(textElement);
+      const textElement=document.createElement("pre"); textElement.textContent=promptItem.text; contentElement.appendChild(textElement);
       cardElement.appendChild(contentElement);
 
       const actionsElement=document.createElement("nav"); actionsElement.className=CLASS_ACTIONS;
-      const copyButtonElement=document.createElement("button"); copyButtonElement.className=CLASS_BUTTON; copyButtonElement.type="button"; copyButtonElement.setAttribute("aria-label",`${COPY_PROMPT_LABEL_PREFIX} ${item.title}`);
-      copyButtonElement.innerHTML=copyIcon()+`<span>${COPY_BUTTON_LABEL}</span>`; copyButtonElement.onclick=()=>copyPrompt(item,cardElement);
+      const copyButtonElement=document.createElement("button"); copyButtonElement.className=CLASS_BUTTON; copyButtonElement.type="button"; copyButtonElement.setAttribute("aria-label",`${COPY_PROMPT_LABEL_PREFIX} ${promptItem.title}`);
+      copyButtonElement.innerHTML=copyIcon()+`<span>${COPY_BUTTON_LABEL}</span>`; copyButtonElement.onclick=()=>copyPrompt(promptItem,cardElement);
       actionsElement.appendChild(copyButtonElement); cardElement.appendChild(actionsElement);
 
-      const toastElement=document.createElement("div"); toastElement.className=CLASS_COPIED; toastElement.textContent=COPIED_TOAST_MESSAGE; cardElement.appendChild(toastElement);
+      const snackbarElement=document.createElement("div"); snackbarElement.className=SNACKBAR_CLASS_NAME; snackbarElement.textContent=COPY_SNACKBAR_MESSAGE; cardElement.appendChild(snackbarElement);
 
       cardElement.addEventListener(EVENT_KEYDOWN, event => {
-        if (event.key === KEY_ENTER) { event.preventDefault(); copyPrompt(item, cardElement); }
+        if (event.key === KEY_ENTER) { event.preventDefault(); copyPrompt(promptItem, cardElement); }
       });
       return cardElement;
     }
 
   /**
-   * copyPrompt writes a prompt's text to the clipboard and shows a toast message.
+   * copyPrompt writes a prompt's text to the clipboard and shows a snackbar message.
    * @param {Object} promptItem prompt data to copy.
    * @param {HTMLElement} cardElement associated card element.
    * @returns {void}
@@ -622,9 +617,8 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   function copyPrompt(promptItem, cardElement) {
     const content = `${promptItem.text}`.trim();
     navigator.clipboard.writeText(sanitize(content)).then(() => {
-      const toastElement = selectOne(`.${CLASS_COPIED}`, cardElement);
-      toastElement.setAttribute(DATA_SHOW_ATTRIBUTE, "true");
-      setTimeout(() => toastElement.setAttribute(DATA_SHOW_ATTRIBUTE, "false"), 1200);
+      const snackbarElement = selectOne(`.${SNACKBAR_CLASS_NAME}`, cardElement);
+      ui(SNACKBAR_CLASS_NAME, snackbarElement);
     }).catch(() => {
       const textareaElement = document.createElement("textarea");
       textareaElement.value = content;


### PR DESCRIPTION
## Summary
- Use Beer.css `chip` components for prompt tags and remove the old tag indicator
- Replace custom copied toast with Beer.css snackbar and use constants for class and message
- Show snackbar via Beer.css `ui` API when copying prompts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55f9ef5848327abe6e81a6091dd00