### PR TITLE
refactor: add app bar with search and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <title>Prompt Bubbles — Curated ChatGPT Prompts</title>
   <meta name="color-scheme" content="dark light" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beercss.min.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
   <script>
     const THEME_STORAGE_KEY = "preferred-theme";
     const LIGHT_THEME = "light";
@@ -21,16 +22,15 @@
   <script defer src="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beercss.min.js"></script>
 </head>
 <body class="light">
-<main class="responsive padding">
-  <nav class="row max center" role="region" aria-label="Search">
+  <header class="top appbar">
     <div class="field prefix suffix round">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 0 0 1.57-4.23C15.99 6.01 13.48 3.5 10.49 3.5S5 6.01 5 9s2.51 5.5 5.5 5.5a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L20 20.49 21.49 19 15.5 14Zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14Z"/></svg>
+      <span class="material-symbols-outlined">search</span>
       <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
-      <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search">✕</button>
+      <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search"><span class="material-symbols-outlined">close</span></button>
     </div>
-    <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme" data-ui="dark icon">🌓</button>
-  </nav>
-
+    <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme"><span class="material-symbols-outlined">dark_mode</span></button>
+  </header>
+<main class="responsive padding">
   <header>
     <div id="headerContainer" aria-label="Site header">
       <i id="headerIcon" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- build a top app bar housing search and theme toggle
- load Material Symbols for new icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a564044cb48327823eadc6d3a9bf86