### PR TITLE
Remove duplicate theme toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,6 @@
     <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme"><span class="material-symbols-outlined">dark_mode</span></button>
   </header>
 <main class="responsive padding">
-    <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme" data-ui="dark icon"><span class="material-symbols-outlined" aria-hidden="true">dark_mode</span></button>
-  </nav>
   <header>
     <div id="headerContainer" aria-label="Site header">
       <span id="headerIcon" class="material-symbols-outlined" aria-hidden="true">bubble_chart</span>


### PR DESCRIPTION
## Summary
- Remove extra theme toggle and stray `</nav>` to fix markup
- Ensure only one theme toggle button remains

## Testing
- `npm test` (fails: ENOENT package.json)
- `node` script to toggle theme and verify storage

------
https://chatgpt.com/codex/tasks/task_e_68a569ab402083279e3dfbd1d0d3a4d7