### PR TITLE
Remove duplicate search icon from appbar search field

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
 <body class="light">
   <header class="top appbar">
     <div class="field prefix suffix round">
-      <span class="material-symbols-outlined">search</span>
       <span class="material-symbols-outlined" aria-hidden="true">search</span>
       <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
       <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search"><span class="material-symbols-outlined">close</span></button>


### PR DESCRIPTION
## Summary
- drop extra visible `search` label span in top appbar search field
- ensure field uses a single prefix icon compatible with Beer.css

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a56bf0cec083278227dde7d36bdc67