### PR TITLE
fix: prevent text cursor on tag elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
     .tag-dot{ width:10px; height:10px; border-radius:50%; background: radial-gradient(circle at 30% 30%, var(--brand), var(--brand-2)); box-shadow:0 0 0 3px color-mix(in lab, var(--brand) 20%, transparent); }
     .card-title{ margin:0; font-size:15px; font-weight:700; letter-spacing:.2px; }
     .card-tags{ display:flex; flex-wrap:wrap; gap:6px; margin-top:-2px; }
-    .tag{ font-size:11px; padding:4px 8px; border-radius:999px; background:color-mix(in lab, var(--brand) 14%, transparent); color:color-mix(in lab, var(--text-0) 85%, var(--brand)); border:1px dashed color-mix(in lab, var(--brand-2) 40%, transparent); }
+    .tag{ font-size:11px; padding:4px 8px; border-radius:999px; background:color-mix(in lab, var(--brand) 14%, transparent); color:color-mix(in lab, var(--text-0) 85%, var(--brand)); border:1px dashed color-mix(in lab, var(--brand-2) 40%, transparent); cursor:pointer; user-select:none; }
     .card-text{ white-space:pre-wrap; font-size:14px; color:var(--text-0); }
 
     .card-actions{ position:absolute; right:10px; bottom:10px; display:flex; gap:8px; }


### PR DESCRIPTION
## Summary
- show pointer cursor for card tags to clarify they are not editable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a572d6c8688327bc2a8c4428dc6dad