### PR TITLE
feat: enhance theme toggle behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,14 @@
 </head>
 <body class="light">
   <header class="top appbar">
-    <div class="field prefix suffix round">
-      <span class="material-symbols-outlined" aria-hidden="true">search</span>
-      <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
-      <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search"><span class="material-symbols-outlined">close</span></button>
-    </div>
-    <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme"><span class="material-symbols-outlined">dark_mode</span></button>
+    <nav>
+      <div class="field prefix suffix round">
+        <span class="material-symbols-outlined" aria-hidden="true">search</span>
+        <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
+        <button class="icon" id="clearSearch" title="Clear search" aria-label="Clear search"><span class="material-symbols-outlined">close</span></button>
+      </div>
+      <button class="circle" id="themeToggle" title="Toggle theme" aria-label="Toggle theme"><span class="material-symbols-outlined">dark_mode</span></button>
+    </nav>
   </header>
 <main class="responsive padding">
   <header>
@@ -46,6 +48,9 @@
 <script type="module" src="https://cdn.jsdelivr.net/npm/beercss@latest/dist/cdn/beer.min.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/material-dynamic-colors@latest/dist/cdn/material-dynamic-colors.min.js"></script>
 <script>
+  const THEME_TOGGLE_BUTTON_ID = "themeToggle";
+  const DARK_MODE_ICON = "dark_mode";
+  const LIGHT_MODE_ICON = "light_mode";
   const HEADER_CONTAINER_ID = "headerContainer";
   const HEADER_ICON_ID = "headerIcon";
   const HEADER_TITLE_ID = "headerTitle";
@@ -762,6 +767,8 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
     document.body.classList.remove(LIGHT_THEME, DARK_THEME);
     document.body.classList.add(nextTheme);
     localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    const themeIconElement = selectOne(`#${THEME_TOGGLE_BUTTON_ID} span`);
+    themeIconElement.textContent = nextTheme === DARK_THEME ? LIGHT_MODE_ICON : DARK_MODE_ICON;
   }
 
   /** init prepares interactive elements. */
@@ -771,18 +778,19 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
     restoreState();
     renderChips();
     renderGrid();
-    const inputElement = selectOne("#searchInput"),
-          clearButton = selectOne("#clearSearch"),
-          themeButton = selectOne("#themeToggle");
-    inputElement.value = state.search;
-    inputElement.addEventListener(EVENT_INPUT, event => onSearch(event.target.value));
-    clearButton.addEventListener(EVENT_CLICK, () => { inputElement.value = ""; inputElement.focus(); onSearch(""); });
-    themeButton.addEventListener(EVENT_CLICK, toggleTheme);
+    const searchInputElement = selectOne("#searchInput"),
+          clearSearchButton = selectOne("#clearSearch"),
+          themeToggleButton = selectOne(`#${THEME_TOGGLE_BUTTON_ID}`);
+    searchInputElement.value = state.search;
+    searchInputElement.addEventListener(EVENT_INPUT, event => onSearch(event.target.value));
+    clearSearchButton.addEventListener(EVENT_CLICK, () => { searchInputElement.value = ""; searchInputElement.focus(); onSearch(""); });
+    themeToggleButton.addEventListener(EVENT_CLICK, toggleTheme);
+    ui();
     window.addEventListener(EVENT_KEYDOWN, event => {
-      if (event.key === KEY_SLASH && document.activeElement !== inputElement) {
+      if (event.key === KEY_SLASH && document.activeElement !== searchInputElement) {
         event.preventDefault();
-        inputElement.focus();
-        inputElement.select();
+        searchInputElement.focus();
+        searchInputElement.select();
       }
     });
   }


### PR DESCRIPTION
## Summary
- nest the theme toggle button in the app bar nav for proper layout
- show light/dark icons when switching themes
- initialize Beer.css UI on the theme button

## Testing
- `node - <<'NODE'` (layout + toggle)
- `node - <<'NODE'` (toggle functionality)


------
https://chatgpt.com/codex/tasks/task_e_68a57285e5708327b50482d22fe542fa