### PR TITLE
Add card header wrapper for consistent title spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,6 +512,8 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   const GROW_CLASS = "grow";
   /** COLUMN_STRETCH_CLASS configures a column layout that stretches children to equal heights. */
   const COLUMN_STRETCH_CLASS = "column stretch";
+  /** CARD_HEADER_CLASS reserves consistent vertical space for card titles. */
+  const CARD_HEADER_CLASS = "min-h-48";
   /** SNACKBAR_CLASS_NAME is the class and component name for Beer.css snackbars. */
   const SNACKBAR_CLASS_NAME = "snackbar";
   /** COPY_SNACKBAR_ID identifies the global snackbar element for copy confirmations. */
@@ -657,9 +659,12 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
       contentElement.className = CLASS_CONTENT;
       contentElement.classList.add(GROW_CLASS);
 
+      const headerWrapperElement = document.createElement(TAG_DIV);
+      headerWrapperElement.className = CARD_HEADER_CLASS;
+
       const titleHeadingElement = document.createElement(TAG_H3);
       titleHeadingElement.innerHTML = escapeHTML(promptItem.title);
-      contentElement.appendChild(titleHeadingElement);
+      headerWrapperElement.appendChild(titleHeadingElement);
 
       const chipContainerElement = document.createElement(TAG_DIV);
       chipContainerElement.className = CLASS_CHIPS;
@@ -669,7 +674,8 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
         chipElement.textContent = tagName;
         chipContainerElement.appendChild(chipElement);
       });
-      contentElement.appendChild(chipContainerElement);
+      headerWrapperElement.appendChild(chipContainerElement);
+      contentElement.appendChild(headerWrapperElement);
 
       const textWrapperElement = document.createElement(TAG_DIV);
       textWrapperElement.className = GROW_CLASS;


### PR DESCRIPTION
## Summary
- define `CARD_HEADER_CLASS` constant for reserved title space
- wrap card titles and tags in a header element using that class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a577c7fa448327a57c61f21174f9b6