### PR TITLE
Align card copy actions to end

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,6 +508,8 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
   const CLASS_BUTTON = "button";
   const CLASS_CHIPS = "chips";
   const CLASS_CHIP = "chip";
+  /** END_ALIGNMENT_CLASS aligns elements to the end of a flex container. */
+  const END_ALIGNMENT_CLASS = "end";
   /** GROW_CLASS expands a flex child to fill available vertical space. */
   const GROW_CLASS = "grow";
   /** COLUMN_STRETCH_CLASS configures a column layout that stretches children to equal heights. */
@@ -682,7 +684,7 @@ For example: "A fresh start will put you on your way." Now your turn!`, tags: ["
       cardElement.appendChild(contentElement);
 
       const actionsElement = document.createElement(TAG_NAV);
-      actionsElement.className = CLASS_ACTIONS;
+      actionsElement.className = `${CLASS_ACTIONS} ${END_ALIGNMENT_CLASS}`;
 
       const copyButtonElement = document.createElement(TAG_BUTTON);
       copyButtonElement.className = CLASS_BUTTON;


### PR DESCRIPTION
## Summary
- add `END_ALIGNMENT_CLASS` to clearly express end alignment class
- apply end alignment to card action container so copy buttons appear at bottom-right

## Testing
- `node <<'NODE'
const {JSDOM} = require('jsdom');
const fs = require('fs');
const html = fs.readFileSync('index.html', 'utf8');
const scriptContent = html.slice(html.lastIndexOf('<script>') + 8, html.lastIndexOf('</script>'));
const dom = new JSDOM('<!doctype html><html><body></body></html>', { runScripts: 'outside-only' });
dom.window.eval(scriptContent);
const card = dom.window.createCard({ id: 't1', title: 'Test', text: 'Body', tags: ['x','y'] });
console.log(card.querySelector('nav').className);
NODE`
- `node <<'NODE'
const { chromium } = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  page.on('console', msg => console.log('PAGE LOG:', msg.text()));
  await page.goto('file://' + process.cwd() + '/index.html');
  try {
    await page.waitForSelector('.card', { timeout: 5000 });
  } catch (err) {
    console.error('waitForSelector failed:', err.message);
  }
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a578c61c3c8327ab9db2d32747ae08