### PR TITLE
fix: expand search bar width and position icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
       <span id="headerIcon" class="material-symbols-outlined" aria-hidden="true">bubble_chart</span>
       <h1 id="headerTitle">Prompt Bubbles</h1>
     </div>
-    <div class="row center middle" id="searchRow">
-      <div class="field prefix suffix round grow" id="searchContainer">
-        <span class="material-symbols-outlined icon prefix" aria-hidden="true">search</span>
+    <div class="row middle" id="searchRow">
+      <div class="field prefix suffix round grow" id="searchContainer" style="width:100%">
+        <i class="material-symbols-outlined icon prefix" aria-hidden="true">search</i>
         <input id="searchInput" type="search" placeholder="Search prompts (title, text, tags)..." autocomplete="off" aria-label="Search prompts" />
         <button class="icon suffix" id="clearSearch" title="Clear search" aria-label="Clear search"><span class="material-symbols-outlined">close</span></button>
       </div>


### PR DESCRIPTION
## Summary
- remove centering restriction so search row spans full width
- widen search container and embed icon element for Beer.css positioning

## Testing
- `python3 -m http.server 8000`
- `curl -sS http://localhost:8000/index.html | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_68a60853eddc8327a60c14a4e15488c5