### PR TITLE
Add small class for tag chips

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const CLASS_ACTIONS = "actions";
 const CLASS_BUTTON = "button";
 const CLASS_CHIPS = "chips";
 const CLASS_CHIP = "chip";
+const CLASS_SMALL = "small";
 const GRID_ITEM_CLASSES = "s12 m6 l4";
 const TEXT_CLASS = "text";
 const CLASS_PROMPT_BODY = "prompt-body";
@@ -82,6 +83,9 @@ function uniqueTags() {
     return [TAG_ALL, ...Array.from(s).sort((a, b) => a.localeCompare(b))];
 }
 
+/**
+ * renderChips builds the tag filter buttons and binds their click handlers.
+ */
 function renderChips() {
     const host = selectOne("#chipBar");
     host.innerHTML = "";
@@ -89,7 +93,7 @@ function renderChips() {
     wrap.className = CLASS_CHIPS;
     uniqueTags().forEach(tagName => {
         const chip = document.createElement("button");
-        chip.className = CLASS_CHIP;
+        chip.className = `${CLASS_CHIP} ${CLASS_SMALL}`;
         chip.type = "button";
         chip.textContent = tagName;
         chip.setAttribute("data-active", tagName === state.tag ? "true" : "false");


### PR DESCRIPTION
## Summary
- add `CLASS_SMALL` constant for small styling
- render tag chips with both chip and small classes
- document `renderChips` in JSDoc format

## Testing
- `npm test` *(fails: Could not read package.json)*
- `NODE_PATH=$(npm root -g) node -e 'const {JSDOM}=require("jsdom");const dom=new JSDOM("<div id=\"chipBar\"></div>");global.document=dom.window.document;const CLASS_CHIPS="chips";const CLASS_CHIP="chip";const CLASS_SMALL="small";const state={tag:"all"};function uniqueTags(){return ["all","tag1"];}function selectOne(sel,root=document){return root.querySelector(sel);}function ui(){}function persistState(){}function renderGrid(){}function highlightActiveChip(){}function renderChips(){const host=selectOne("#chipBar");host.innerHTML="";const wrap=document.createElement("div");wrap.className=CLASS_CHIPS;uniqueTags().forEach(tagName=>{const chip=document.createElement("button");chip.className=`${CLASS_CHIP} ${CLASS_SMALL}`;chip.type="button";chip.textContent=tagName;chip.setAttribute("data-active",tagName===state.tag?"true":"false");chip.onclick=()=>{state.tag=tagName;persistState();renderGrid();highlightActiveChip();};wrap.appendChild(chip);});host.appendChild(wrap);ui(CLASS_CHIPS,wrap);}renderChips();console.log(document.querySelector("button").className);'`

------
https://chatgpt.com/codex/tasks/task_e_68a621fcf0808327b541e84ac0f3a4e9