### PR TITLE
ci: add pull request preview deployment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,57 @@
+name: Pull Request Preview
+
+on:
+  pull_request:
+    paths:
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.json'
+
+jobs:
+  DeployPreview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PUBLISH_BRANCH: gh-pages
+      PREVIEW_PREFIX: pr
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BASE_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+      PREVIEW_NOTE_PREFIX: Preview location:
+    steps:
+      - name: CheckoutRepository
+        uses: actions/checkout@v4
+      - id: PreparePreviewContent
+        run: |
+          preview_directory="${{ env.PREVIEW_PREFIX }}-${{ github.event.pull_request.number }}"
+          mkdir -p "$preview_directory"
+          rsync -av --exclude '.git' --exclude '.github' ./ "$preview_directory/"
+          echo "preview_directory=$preview_directory" >> "$GITHUB_OUTPUT"
+      - name: DeployPreview
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ env.GITHUB_TOKEN }}
+          publish_branch: ${{ env.PUBLISH_BRANCH }}
+          publish_dir: ${{ steps.PreparePreviewContent.outputs.preview_directory }}
+          destination_dir: ${{ steps.PreparePreviewContent.outputs.preview_directory }}
+          keep_files: true
+      - name: PublishPreviewComment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_DIRECTORY: ${{ steps.PreparePreviewContent.outputs.preview_directory }}
+        with:
+          script: |
+            const botUserType = 'Bot'
+            const previewUrl = `${process.env.BASE_PAGES_URL}/${process.env.PREVIEW_DIRECTORY}/`
+            const message = `${process.env.PREVIEW_NOTE_PREFIX} ${previewUrl}`
+            const pullRequestNumber = context.payload.pull_request.number
+            const { data: comments } = await github.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pullRequestNumber })
+            const previous = comments.find(comment => comment.user.type === botUserType && comment.body.startsWith(process.env.PREVIEW_NOTE_PREFIX))
+            if (previous) {
+              await github.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: previous.id, body: message })
+            } else {
+              await github.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pullRequestNumber, body: message })
+            }


### PR DESCRIPTION
## Summary
- deploy pull request previews for front-end changes on GitHub Pages
- comment pull requests with a direct link to the preview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab452731a883278e065098035efd5c