### PR TITLE
fix: move Google Analytics initialization to HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,3 @@
-/** initializeAnalytics configures Google Analytics tracking */
-window.dataLayer = window.dataLayer || [];
-function gtag(){ dataLayer.push(arguments); }
-const ANALYTICS_ID = "G-R6J165F21E";
-gtag("js", new Date());
-gtag("config", ANALYTICS_ID);
-
 let promptsList = [];
 const PROMPTS_PATH = "prompts.json";
 /** loadPrompts retrieves prompt data from a JSON file and assigns it to the global list */

--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
 
   <link rel="stylesheet" href="prompt-bubbles.css" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-R6J165F21E"></script>
+  <script>
+    /** analyticsId identifies the site for Google Analytics */
+    const ANALYTICS_ID = "G-R6J165F21E";
+    /** gtag pushes analytics events to the data layer */
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag("js", new Date());
+    gtag("config", ANALYTICS_ID);
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- initialize Google Analytics directly in index.html
- remove analytics setup from application script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2329621808327a73622557a72ec93