### PR TITLE
Centralize share icon markup

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const DOM_CONTENT_LOADED_EVENT = "DOMContentLoaded";
 const BUTTON_CLASS = "btn";
 const SHARE_BUTTON_CLASS = "card-share";
 const ARIA_SHARE_LABEL = "Copy card link:";
+const SHARE_ICON_SVG = `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A3 3 0 1 1 18 6a3 3 0 0 1-2.05-.81L8.94 9.23a3 3 0 1 0 0 5.54l7.01 4.1A3 3 0 1 1 18 16.08z"/></svg>`;
 const HASH_SYMBOL = "#";
 const PLACEHOLDER_PATTERN = /\{([^}]+)\}/g;
 const PLACEHOLDER_ATTRIBUTE = "data-placeholder";
@@ -259,9 +260,9 @@ function copyIcon() {
   return `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`;
 }
 
-/** shareIcon returns the SVG for the share button */
+/** shareIcon returns the share icon SVG markup */
 function shareIcon() {
-  return `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A3 3 0 1 1 18 6a3 3 0 0 1-2.05-.81L8.94 9.23a3 3 0 1 0 0 5.54l7.01 4.1A3 3 0 1 1 18 16.08z"/></svg>`;
+  return SHARE_ICON_SVG;
 }
 
 /** escapeHTML escapes special characters for safe HTML insertion */


### PR DESCRIPTION
## Summary
- add `SHARE_ICON_SVG` constant for share button
- refactor `shareIcon` to return constant and document function

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2332f4f90832782b81693e0aa35c8