### PR TITLE
chore: pin share icon asset

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,8 @@ const DOM_CONTENT_LOADED_EVENT = "DOMContentLoaded";
 const BUTTON_CLASS = "btn";
 const SHARE_BUTTON_CLASS = "card-share";
 const ARIA_SHARE_LABEL = "Copy card link:";
-const SHARE_ICON_SVG = `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A3 3 0 1 1 18 6a3 3 0 0 1-2.05-.81L8.94 9.23a3 3 0 1 0 0 5.54l7.01 4.1A3 3 0 1 1 18 16.08z"/></svg>`;
+const SHARE_ICON_IMAGE_SRC = "https://cdn.jsdelivr.net/npm/@material-design-icons/svg@0.14.15/filled/share.svg";
+const SHARE_ICON_ALT_TEXT = "Share icon";
 const HASH_SYMBOL = "#";
 const PLACEHOLDER_PATTERN = /\{([^}]+)\}/g;
 const PLACEHOLDER_ATTRIBUTE = "data-placeholder";
@@ -253,9 +254,9 @@ function copyIcon() {
   return `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`;
 }
 
-/** shareIcon returns the share icon SVG markup */
+/** shareIcon returns the markup for the share icon image element */
 function shareIcon() {
-  return SHARE_ICON_SVG;
+  return `<img src="${SHARE_ICON_IMAGE_SRC}" alt="${SHARE_ICON_ALT_TEXT}" />`;
 }
 
 /** escapeHTML escapes special characters for safe HTML insertion */


### PR DESCRIPTION
## Summary
- pin share icon to versioned jsDelivr CDN asset
- render share button using CDN-hosted icon markup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://cdn.jsdelivr.net/npm/@material-design-icons/svg@0.14.15/filled/share.svg` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2388bd4c48327b26b97c858cf65fc