### PR TITLE
Ensure CDN share icon uses theme colors

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -20,8 +20,8 @@ const DOM_CONTENT_LOADED_EVENT = "DOMContentLoaded";
 const BUTTON_CLASS = "btn";
 const SHARE_BUTTON_CLASS = "card-share";
 const ARIA_SHARE_LABEL = "Copy card link:";
-const SHARE_ICON_IMAGE_SRC = "https://cdn.jsdelivr.net/npm/@material-design-icons/svg@0.14.15/filled/share.svg";
-const SHARE_ICON_ALT_TEXT = "Share icon";
+const SHARE_ICON_IMAGE_SOURCE = "https://cdn.jsdelivr.net/npm/@material-design-icons/svg@0.14.15/filled/share.svg";
+const SHARE_ICON_ALTERNATIVE_TEXT = "Share icon";
 const HASH_SYMBOL = "#";
 const PLACEHOLDER_PATTERN = /\{([^}]+)\}/g;
 const PLACEHOLDER_ATTRIBUTE = "data-placeholder";
@@ -256,7 +256,7 @@ function copyIcon() {
 
 /** shareIcon returns the markup for the share icon image element */
 function shareIcon() {
-  return `<img src="${SHARE_ICON_IMAGE_SRC}" alt="${SHARE_ICON_ALT_TEXT}" />`;
+  return `<img src="${SHARE_ICON_IMAGE_SOURCE}" alt="${SHARE_ICON_ALTERNATIVE_TEXT}" />`;
 }
 
 /** escapeHTML escapes special characters for safe HTML insertion */

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -104,6 +104,10 @@
 
     .card-actions{ position:absolute; right:10px; bottom:10px; display:flex; gap:8px; }
     .card-share{ position:absolute; left:10px; bottom:10px; }
+    .card-share img{ filter:invert(1); }
+    @media (prefers-color-scheme: light){
+      .card-share img{ filter:invert(0); }
+    }
     .btn{ display:inline-flex; align-items:center; gap:8px; border:1px solid rgba(255,255,255,.16); background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02)); padding:8px 12px; border-radius:12px; cursor:pointer; user-select:none; color:var(--text-0); }
     .btn:hover{ border-color: color-mix(in lab, var(--brand) 40%, transparent) }
     .btn:active{ transform: translateY(1px) }


### PR DESCRIPTION
## Summary
- Invert share icon via CSS so the CDN image matches button text in dark mode
- Reset inversion for light mode to retain dark icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e20a7c88327a7aa489fdc08d40b