### PR TITLE
Add BeatBot celebration prompt

### DIFF
--- a/assets/data/prompts.json
+++ b/assets/data/prompts.json
@@ -897,5 +897,14 @@
       "personal",
       "fun"
     ]
+  },
+  {
+    "id": "p106",
+    "title": "BeatBot Celebration",
+    "text": "Use BeatBot to make a sick beat to celebrate {CELEBRATION}.",
+    "tags": [
+      "creative",
+      "fun"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add BeatBot celebration prompt with placeholder for any occasion

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24824784c832798f708820e9e34e6